### PR TITLE
Added platform version to fix error

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:d1_mini_lite]
-platform = espressif8266
+platform = espressif8266 @ 2.5.0
 ; board = d1_mini
 board = d1_mini_lite
 framework = arduino


### PR DESCRIPTION
Platform IO error caused by wrong platform version. I just set the version to 2.5.0 which fixes this error.
`error: call to 'HTTPClient::begin' declared with attribute error: obsolete API, use ::begin(WiFiClient, url)`
